### PR TITLE
chore: improve api for cors rules

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -31,11 +31,11 @@ variable "website_documents" {
 variable "cors_rules" {
   type = list(
     object({
-      allowed_headers = list(string)
+      allowed_headers = optional(list(string))
       allowed_methods = list(string)
       allowed_origins = list(string)
-      expose_headers  = list(string)
-      max_age_seconds = number
+      expose_headers  = optional(list(string))
+      max_age_seconds = optional(number)
     })
   )
   default = []


### PR DESCRIPTION
_Allowed headers_, _expose headers_, _max age_ are all non-required by
the TF resource. It also makes sense not to specify them from
a developers' perspective.